### PR TITLE
refactor: Update project name to `Teeny`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,8 +13,8 @@ rustflags = [
 
   # # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.) on riscv32imc targets.
   # # NOTE: May negatively impact performance of produced code
-  # "-C",
-  # "force-frame-pointers",
+  "-C",
+  "force-frame-pointers",
 ]
 
 target = "riscv32imc-unknown-none-elf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,39 +1458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spotify-mini"
-version = "0.1.0"
-dependencies = [
- "display-interface",
- "dotenv",
- "embassy-embedded-hal",
- "embassy-executor",
- "embassy-net",
- "embassy-sync 0.6.0",
- "embassy-time",
- "embedded-graphics",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-hal-bus",
- "embedded-io",
- "embedded-io-async",
- "embedded-svc",
- "esp-backtrace",
- "esp-hal",
- "esp-hal-embassy",
- "esp-println",
- "esp-wifi",
- "heapless",
- "httparse",
- "libm",
- "log",
- "reqwless",
- "smoltcp",
- "ssd1306",
- "static_cell",
-]
-
-[[package]]
 name = "ssd1306"
 version = "0.9.0"
 source = "git+https://github.com/embedevices-rs/ssd1306?branch=async#d13d2e9f48c4fa10cc57731e3171d79d839180e0"
@@ -1585,6 +1552,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "teeny"
+version = "0.1.0"
+dependencies = [
+ "display-interface",
+ "dotenv",
+ "embassy-embedded-hal",
+ "embassy-executor",
+ "embassy-net",
+ "embassy-sync 0.6.0",
+ "embassy-time",
+ "embedded-graphics",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-bus",
+ "embedded-io",
+ "embedded-io-async",
+ "embedded-svc",
+ "esp-backtrace",
+ "esp-hal",
+ "esp-hal-embassy",
+ "esp-println",
+ "esp-wifi",
+ "heapless",
+ "httparse",
+ "libm",
+ "log",
+ "reqwless",
+ "smoltcp",
+ "ssd1306",
+ "static_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spotify-mini"
+name = "teeny"
 version = "0.1.0"
 authors = ["Sycrosity <72102935+Sycrosity@users.noreply.github.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-`Spotify Mini Controller`
+`Teeny`
 ==================
-![CI](https://github.com/Sycrosity/spotify-mini/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/Sycrosity/teeny/actions/workflows/ci.yml/badge.svg)
 
-A teeny tiny Spotify Controller for esp32 devices.
+A teeny tiny esp32c3 powered spotify controller.
 -------
 
 ## Download & run
@@ -11,8 +11,8 @@ A teeny tiny Spotify Controller for esp32 devices.
 
 1. Install rust at [rustup.rs](https://rustup.rs)
 2. Install espup at [esp-rs/espup](https://github.com/esp-rs/espup)
-3. Clone the repo `git clone https://github.com/Sycrosity/spotify-mini.git`
-4. `cd spotify-mini`
+3. Clone the repo `git clone https://github.com/Sycrosity/teeny.git`
+4. `cd teeny`
 5. Install `just` at [just.systems](https://just.systems/) (or with `cargo install just`)
 6. Run with your selected board type, e.g. `just run esp32c3`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use esp_hal::{
 use esp_println::println;
 use esp_wifi::wifi::WifiStaDevice;
 use httparse::{Header, Status};
-use spotify_mini::{
+use teeny::{
     blink::blink,
     buttons::{
         display_play_pause, display_skip, publish_play_pause, publish_raw_skip, publish_skip,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main(spawner: Spawner) -> ! {
     // this requires a clean rebuild because of https://github.com/
     // rust-lang/cargo/issues/10358
     #[cfg(feature = "log")]
-    spotify_mini::logger::init_logger_from_env();
+    teeny::logger::init_logger_from_env();
     info!("Logger is setup");
     println!("Hello world!");
 

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,5 +1,5 @@
 [wokwi]
 version = 1
 gdbServerPort = 3333
-elf = "target/riscv32imc-unknown-none-elf/release/spotify-mini"
-firmware = "target/riscv32imc-unknown-none-elf/release/spotify-mini"
+elf = "target/riscv32imc-unknown-none-elf/release/teeny"
+firmware = "target/riscv32imc-unknown-none-elf/release/teeny"


### PR DESCRIPTION
+ Migrate project name, folder, and references to `Teeny` from `Spotify Mini Controller`.
+ Update `README.md` badges and description to reflect the new project name.